### PR TITLE
Register caches before plugins

### DIFF
--- a/API.md
+++ b/API.md
@@ -47,19 +47,19 @@ Here's the complete rundown of how files and directories are mapped to API calls
   - **`path.js`** - export `relativeTo`.
   - **`path/index.js`** - export `relativeTo`.
 
-#### Plugin registrations
-> [`await server.register(plugins, [options])`](https://github.com/hapijs/hapi/blob/master/API.md#server.register())
-
-  - **`plugins.js`** - export an array of objects `{ plugins, options }`.
-  - **`plugins/index.js`** - export an array of objects.
-  - **`plugins/plugin-name.js`** - export an object.  If a plugin isn't specified in `plugins` it will be `require()`d using the filename.
-
 #### Provisioning caches
 > [`await server.cache.provision(options)`](https://github.com/hapijs/hapi/blob/master/API.md#server.cache.provision())
 
   - **`caches.js`** - export an array of `options`.
   - **`caches/index.js`** - export an array of `options`.
   - **`caches/some-cache-name.js`** - export `options`.  The cache's `options.name` will be assigned `'cache-name'` from the filename if a name isn't already specified.
+
+#### Plugin registrations
+> [`await server.register(plugins, [options])`](https://github.com/hapijs/hapi/blob/master/API.md#server.register())
+
+  - **`plugins.js`** - export an array of objects `{ plugins, options }`.
+  - **`plugins/index.js`** - export an array of objects.
+  - **`plugins/plugin-name.js`** - export an object.  If a plugin isn't specified in `plugins` it will be `require()`d using the filename.
 
 #### View manager (for [vision](https://github.com/hapijs/vision))
 > [`server.views(options)`](https://github.com/hapijs/vision/blob/master/API.md#serverviewsoptions)

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -123,6 +123,17 @@ internals.manifest = [
         after: ['services']
     },
     {
+        place: 'caches',
+        method: 'cache.provision',
+        async: true,
+        list: true,
+        useFilename: internals.passthruOn('name'),
+        example: {
+            engine: null,
+            name: ''
+        }
+    },
+    {
         place: 'plugins',
         method: 'register',
         signature: ['plugins', '[options]'],
@@ -157,17 +168,6 @@ internals.manifest = [
         example: {
             dependencies: [],
             after: { $value: async (server) => {}, $comment: 'Optional' }
-        }
-    },
-    {
-        place: 'caches',
-        method: 'cache.provision',
-        async: true,
-        list: true,
-        useFilename: internals.passthruOn('name'),
-        example: {
-            engine: null,
-            name: ''
         }
     },
     {

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -153,6 +153,7 @@ internals.manifest = [
 
             return value;
         },
+        after: ['caches'],
         example: {
             plugins: { $value: [], $comment: 'May be an array or a single plugin' },
             options: { $value: {}, $comment: 'Optional' }

--- a/test/index.js
+++ b/test/index.js
@@ -436,8 +436,8 @@ describe('HauteCouture', () => {
 
                 expect(summary).to.equal([
                     'path() at path',
-                    'register() at plugins',
                     'cache.provision() at caches',
+                    'register() at plugins',
                     'views() at view-manager',
                     'decorate() at decorations',
                     'expose() at expose',
@@ -479,8 +479,8 @@ describe('HauteCouture', () => {
 
                 expect(summary).to.equal([
                     'path() at path',
-                    'register() at plugins',
                     'cache.provision() at caches',
+                    'register() at plugins',
                     'views() at view-manager',
                     'decorate() at decorations',
                     'expose() at expose',


### PR DESCRIPTION
Some plugins may have cache dependencies. In order to make cache
configurations available to plugins, this commit switches the order of
registration.

Closes #38