### PR TITLE
Nested directories, scoped plugin packages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,9 +20,18 @@ exports.using = (dirname, manifestAmendments) => {
     dirname = dirname || Path.dirname(ParentModule());
     manifestAmendments = manifestAmendments || internals.maybeGetHcFile(dirname);
 
-    const manifest = Manifest.create(manifestAmendments);
+    const manifest = Manifest.create(manifestAmendments).map((item) => ({
+        ...item,
+        useFilename: item.useFilename && ((value, filename, path) => item.useFilename(filename, value, path)),
+        dirname
+    }));
 
-    return Haute.using(dirname, 'server', manifest);
+    return async (server, ...options) => {
+
+        const calls = Haute.calls('server', manifest);
+
+        return await Haute.run(calls, server, ...options);
+    };
 };
 
 internals.maybeGetHcFile = (dirname) => {

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Path = require('path');
 const Topo = require('topo');
 const Hoek = require('hoek');
 
@@ -12,6 +13,12 @@ exports.create = (amendments, includeExtras) => {
     if (Array.isArray(amendments)) {
         amendments = { add: amendments };
     }
+
+    const recurse = !!amendments.recurse;
+    const include = amendments.include;
+    const exclude = (include || amendments.exclude) ?
+        amendments.exclude :
+        (filename, path) => path.split(Path.sep).includes('helpers');
 
     const add = Hoek.flatten([].concat(amendments.add || [])); // Allow nested [{}, [{}]]
     const remove = [].concat(amendments.remove || []);
@@ -38,7 +45,7 @@ exports.create = (amendments, includeExtras) => {
 
     return topoList.nodes.map((item) => {
 
-        item = Hoek.shallow(item);
+        item = Hoek.applyToDefaults({ recurse, include, exclude }, item);
 
         if (!includeExtras) {
             delete item.before;
@@ -70,22 +77,33 @@ internals.camelize = (name) => {
     return name.replace(/[_-]./g, (m) => m[1].toUpperCase());
 };
 
+// E.g. a/b/c.d.js -> a-b-c.d
+internals.normalizePath = (p) => {
+
+    return Path.join(
+        Path.dirname(p),
+        Path.basename(p, Path.extname(p))
+    )
+        .split(Path.sep)
+        .join('-');
+};
+
 internals.camelizeOn = (prop) => {
 
-    return (filename, value) => {
+    return (filename, value, path) => {
 
         const base = {};
-        base[prop] = internals.camelize(filename);
+        base[prop] = internals.camelize(internals.normalizePath(path));
         return Hoek.applyToDefaults(base, value);
     };
 };
 
 internals.passthruOn = (prop) => {
 
-    return (filename, value) => {
+    return (filename, value, path) => {
 
         const base = {};
-        base[prop] = filename;
+        base[prop] = internals.normalizePath(path);
         return Hoek.applyToDefaults(base, value);
     };
 };
@@ -143,12 +161,15 @@ internals.manifest = [
 
             value = Hoek.shallow(value);
 
+            // Adjust for scoped module, e.g. @scoped.package -> @scoped/package
+            const modulePath = filename.replace(/^@.+?\./, (m) => m.slice(0, -1) + '/');
+
             if (!value.plugins) {
-                value.plugins = require(filename);
+                value.plugins = require(modulePath);
             }
             else if (!Array.isArray(value.plugins) && !value.plugins.plugin) {
                 value.plugins = Hoek.shallow(value.plugins);
-                value.plugins.plugin = require(filename);
+                value.plugins.plugin = require(modulePath);
             }
 
             return value;
@@ -175,13 +196,13 @@ internals.manifest = [
         place: 'methods',
         method: 'method',
         list: true,
-        useFilename: (filename, value) => {
+        useFilename: (filename, value, path) => {
 
             if (Array.isArray(value)) {
                 return value;
             }
 
-            return internals.camelizeOn('name')(filename, value);
+            return internals.camelizeOn('name')(filename, value, path);
         },
         after: ['bind', 'caches', 'plugins'],
         example: {
@@ -201,13 +222,13 @@ internals.manifest = [
         method: 'decorate',
         signature: ['type', 'property', 'method', '[options]'],
         list: true,
-        useFilename: (filename, value) => {
+        useFilename: (filename, value, path) => {
 
-            const parts = filename.split('.');
+            const parts = internals.normalizePath(path).split('.');
 
             if (parts.length === 1) {
                 // [prop].js on { type, method, options }
-                return internals.camelizeOn('property')(filename, value);
+                return internals.camelizeOn('property')(filename, value, path);
             }
             else if (parts.length === 2) {
                 // [type].[prop].js on { method, options }
@@ -230,15 +251,15 @@ internals.manifest = [
         place: 'extensions',
         method: 'ext',
         list: true,
-        useFilename: (filename, value) => {
+        useFilename: (filename, value, path) => {
 
             const applyType = internals.camelizeOn('type');
 
             if (Array.isArray(value)) {
-                return value.map((item) => applyType(filename, item));
+                return value.map((item) => applyType(filename, item, path));
             }
 
-            return applyType(filename, value);
+            return applyType(filename, value, path);
         },
         after: ['bind', 'plugins'],
         example: {
@@ -320,21 +341,22 @@ internals.manifest = [
         place: 'routes',
         method: 'route',
         list: true,
-        useFilename: (filename, value) => {
+        useFilename: (filename, value, path) => {
 
             if (Array.isArray(value)) {
                 return value;
             }
 
+            path = internals.normalizePath(path);
             value = Hoek.applyToDefaults({}, value);
 
             // Support both `config` and `options` props on route
 
             if (value.config) {
-                value.config = Hoek.applyToDefaults({ id: filename }, value.config);
+                value.config = Hoek.applyToDefaults({ id: path }, value.config);
             }
             else {
-                value.options = Hoek.applyToDefaults({ id: filename }, value.options || {});
+                value.options = Hoek.applyToDefaults({ id: path }, value.options || {});
             }
 
             return value;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/hapipal/haute-couture#readme",
   "dependencies": {
-    "haute": "2.x.x",
+    "haute": "next",
     "hoek": "5.x.x",
     "parent-module": "0.1.x",
     "topo": "3.x.x"
@@ -43,6 +43,7 @@
     "hapi": ">=17 <18"
   },
   "devDependencies": {
+    "@softonic/hapi-error-logger": "2.x.x",
     "catbox-memory": "3.x.x",
     "code": "5.x.x",
     "coveralls": "3.x.x",

--- a/test/closet/plugins/@softonic.hapi-error-logger.js
+++ b/test/closet/plugins/@softonic.hapi-error-logger.js
@@ -1,0 +1,4 @@
+'use strict';
+
+// No plugins specified, with scoped module
+module.exports = {};

--- a/test/closet/recurse/routes/helpers/index.js
+++ b/test/closet/recurse/routes/helpers/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+exports.createRoute = (name) => ({
+    method: 'get',
+    path: `/${name}`,
+    handler: () => name
+});

--- a/test/closet/recurse/routes/item-one.js
+++ b/test/closet/recurse/routes/item-one.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const Helpers = require('./helpers');
+
+module.exports = Helpers.createRoute('item-one');

--- a/test/closet/recurse/routes/one/a/item-one.js
+++ b/test/closet/recurse/routes/one/a/item-one.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const Helpers = require('../../helpers');
+
+module.exports = Helpers.createRoute('one/a/item-one');

--- a/test/closet/recurse/routes/one/a/item-two.js
+++ b/test/closet/recurse/routes/one/a/item-two.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const Helpers = require('../../helpers');
+
+module.exports = Helpers.createRoute('one/a/item-two');

--- a/test/closet/recurse/routes/one/b/item-one.js
+++ b/test/closet/recurse/routes/one/b/item-one.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const Helpers = require('../../helpers');
+
+module.exports = Helpers.createRoute('one/b/item-one');

--- a/test/closet/recurse/routes/two/a/item-one.js
+++ b/test/closet/recurse/routes/two/a/item-one.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const Helpers = require('../../helpers');
+
+module.exports = Helpers.createRoute('two/a/item-one');

--- a/test/closet/recurse/routes/two/item-one.js
+++ b/test/closet/recurse/routes/two/item-one.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const Helpers = require('../helpers');
+
+module.exports = Helpers.createRoute('two/item-one');

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,7 @@
 
 // Load modules
 
+const Path = require('path');
 const Lab = require('lab');
 const Code = require('code');
 const Hapi = require('hapi');
@@ -192,14 +193,18 @@ describe('HauteCouture', () => {
 
     it('registers plugins in plugins/.', () => {
 
-        // plugins specified, but not an array and no `plugin`
+        // Plugins specified, but not an array and no `plugin`
         expect(bigServer.registrations.schwifty).to.exist();
 
         // No plugins specified
         expect(bigServer.registrations.vision).to.exist();
 
+        // No plugins specified, with scoped module
+        expect(bigServer.registrations['@softonic/hapi-error-logger']).to.exist();
+
         // Passes options, plugins specified as array
         expect(bigServer.registrations['test-dep']).to.exist();
+
         expect(bigServer.app.sawPluginOptions).to.equal('/options');
     });
 
@@ -415,9 +420,99 @@ describe('HauteCouture', () => {
         await expect(HauteCouture.using(`${__dirname}/closet/bad-plugin`)(server)).to.reject(/Ya blew it!/);
     });
 
+    it('does not recurse by default.', async () => {
+
+        const server = Hapi.server();
+
+        const plugin = {
+            register: HauteCouture.using(`${__dirname}/closet/recurse`),
+            name: 'my-recurse-plugin'
+        };
+
+        await server.register(plugin);
+
+        expect(server.table().map((r) => r.settings.id)).to.equal([
+            'item-one'
+        ]);
+    });
+
+    it('recurses, skipping helpers by default.', async () => {
+
+        const server = Hapi.server();
+
+        const plugin = {
+            register: HauteCouture.using(`${__dirname}/closet/recurse`, {
+                recurse: true
+            }),
+            name: 'my-recurse-plugin'
+        };
+
+        await server.register(plugin);
+
+        expect(server.table().map((r) => r.settings.id)).to.equal([
+            'item-one',
+            'two-item-one',
+            'one-a-item-one',
+            'one-a-item-two',
+            'one-b-item-one',
+            'two-a-item-one'
+        ]);
+    });
+
+    it('recurses with exclusion.', async () => {
+
+        const server = Hapi.server();
+
+        const plugin = {
+            register: HauteCouture.using(`${__dirname}/closet/recurse`, {
+                recurse: true,
+                exclude: (filename, path) => {
+
+                    return path.split(Path.sep).includes('a') ||
+                        path.split(Path.sep).includes('helpers');
+                }
+            }),
+            name: 'my-recurse-plugin'
+        };
+
+        await server.register(plugin);
+
+        expect(server.table().map((r) => r.settings.id)).to.equal([
+            'item-one',
+            'two-item-one',
+            'one-b-item-one'
+        ]);
+    });
+
+    it('recurses with inclusion.', async () => {
+
+        const server = Hapi.server();
+
+        const plugin = {
+            register: HauteCouture.using(`${__dirname}/closet/recurse`, {
+                recurse: true,
+                include: (filename, path) => {
+
+                    return path.split(Path.sep).includes('one');
+                }
+            }),
+            name: 'my-recurse-plugin'
+        };
+
+        await server.register(plugin);
+
+        expect(server.table().map((r) => r.settings.id)).to.equal([
+            'one-a-item-one',
+            'one-a-item-two',
+            'one-b-item-one'
+        ]);
+    });
+
     describe('manifest', () => {
 
         describe('create()', () => {
+
+            const ignoreFields = ({ include, exclude, ...item }) => item;
 
             it('returns the default haute manifest.', () => {
 
@@ -428,7 +523,10 @@ describe('HauteCouture', () => {
                     signature: Joi.array().items(Joi.string().regex(/^\[?\w+\]?$/)),
                     async: Joi.boolean(),
                     list: Joi.boolean(),
-                    useFilename: Joi.func()
+                    useFilename: Joi.func(),
+                    recurse: Joi.boolean(),
+                    exclude: Joi.func(),
+                    include: Joi.func()
                 }));
 
                 const summarize = (item) => `${item.method}() at ${item.place}`;
@@ -469,6 +567,9 @@ describe('HauteCouture', () => {
                     async: Joi.boolean(),
                     list: Joi.boolean(),
                     useFilename: Joi.func(),
+                    recurse: Joi.boolean(),
+                    exclude: Joi.func(),
+                    include: Joi.func(),
                     before: Joi.array().items(Joi.string()).single(),
                     after: Joi.array().items(Joi.string()).single(),
                     example: Joi.any()
@@ -500,10 +601,11 @@ describe('HauteCouture', () => {
 
             it('removes single item from the manifest by place.', () => {
 
-                const defaultManifest = HauteCouture.manifest.create();
+                const defaultManifest = HauteCouture.manifest.create().map(ignoreFields);
                 const manifest = HauteCouture.manifest.create({
                     remove: 'routes'
-                });
+                })
+                    .map(ignoreFields);
 
                 expect(manifest.length).to.equal(defaultManifest.length - 1);
 
@@ -515,10 +617,11 @@ describe('HauteCouture', () => {
 
             it('removes items from the manifest by place.', () => {
 
-                const defaultManifest = HauteCouture.manifest.create();
+                const defaultManifest = HauteCouture.manifest.create().map(ignoreFields);
                 const manifest = HauteCouture.manifest.create({
                     remove: ['auth/default', 'routes'] // Bottom two
-                });
+                })
+                    .map(ignoreFields);
 
                 expect(manifest.length).to.equal(defaultManifest.length - 2);
 
@@ -530,13 +633,14 @@ describe('HauteCouture', () => {
 
             it('replaces items in the manifest by place.', () => {
 
-                const defaultManifest = HauteCouture.manifest.create();
+                const defaultManifest = HauteCouture.manifest.create().map(ignoreFields);
                 const manifest = HauteCouture.manifest.create({
                     add: [{
                         place: 'routes',
                         method: 'myRoute'
                     }]
-                });
+                })
+                    .map(ignoreFields);
 
                 const allOthers = (item) => item.place !== 'routes';
                 expect(manifest.filter(allOthers)).to.equal(defaultManifest.filter(allOthers));
@@ -544,13 +648,14 @@ describe('HauteCouture', () => {
                 const routeItem = manifest.find((item) => item.place === 'routes');
                 expect(routeItem).to.equal({
                     place: 'routes',
-                    method: 'myRoute'
+                    method: 'myRoute',
+                    recurse: false
                 });
             });
 
             it('replaces items in the manifest by place.', () => {
 
-                const defaultManifest = HauteCouture.manifest.create();
+                const defaultManifest = HauteCouture.manifest.create().map(ignoreFields);
                 const manifest = HauteCouture.manifest.create({
                     add: [
                         {
@@ -562,7 +667,8 @@ describe('HauteCouture', () => {
                             method: 'mySchwifty'
                         }
                     ]
-                });
+                })
+                    .map(ignoreFields);
 
                 const allOthers = (item) => item.place !== 'routes' && item.place !== 'models';
                 expect(manifest.filter(allOthers)).to.equal(defaultManifest.filter(allOthers));
@@ -570,31 +676,35 @@ describe('HauteCouture', () => {
                 const routeItem = manifest.find((item) => item.place === 'routes');
                 expect(routeItem).to.equal({
                     place: 'routes',
-                    method: 'myRoute'
+                    method: 'myRoute',
+                    recurse: false
                 });
 
                 const schwiftyItem = manifest.find((item) => item.place === 'models');
                 expect(schwiftyItem).to.equal({
                     place: 'models',
-                    method: 'mySchwifty'
+                    method: 'mySchwifty',
+                    recurse: false
                 });
             });
 
             it('adds new items to the manifest.', () => {
 
-                const defaultManifest = HauteCouture.manifest.create();
+                const defaultManifest = HauteCouture.manifest.create().map(ignoreFields);
                 const manifest = HauteCouture.manifest.create({
                     add: [
                         {
                             place: 'funky-routes',
-                            method: 'funkyRoutes'
+                            method: 'funkyRoutes',
+                            recurse: true
                         },
                         {
                             place: 'funky-bind',
                             method: 'funkyBind'
                         }
                     ]
-                });
+                })
+                    .map(ignoreFields);
 
                 defaultManifest.forEach((item, i) => {
 
@@ -606,24 +716,27 @@ describe('HauteCouture', () => {
 
                 expect(manifest[defaultLength]).to.equal({
                     place: 'funky-routes',
-                    method: 'funkyRoutes'
+                    method: 'funkyRoutes',
+                    recurse: true
                 });
 
                 expect(manifest[defaultLength + 1]).to.equal({
                     place: 'funky-bind',
-                    method: 'funkyBind'
+                    method: 'funkyBind',
+                    recurse: false
                 });
             });
 
             it('adds new single item to the manifest.', () => {
 
-                const defaultManifest = HauteCouture.manifest.create();
+                const defaultManifest = HauteCouture.manifest.create().map(ignoreFields);
                 const manifest = HauteCouture.manifest.create({
                     add: {
                         place: 'funky-routes',
                         method: 'funkyRoutes'
                     }
-                });
+                })
+                    .map(ignoreFields);
 
                 defaultManifest.forEach((item, i) => {
 
@@ -635,13 +748,14 @@ describe('HauteCouture', () => {
 
                 expect(manifest[defaultLength]).to.equal({
                     place: 'funky-routes',
-                    method: 'funkyRoutes'
+                    method: 'funkyRoutes',
+                    recurse: false
                 });
             });
 
             it('respects before/after options for additional items.', () => {
 
-                const defaultManifest = HauteCouture.manifest.create();
+                const defaultManifest = HauteCouture.manifest.create().map(ignoreFields);
                 const manifest = HauteCouture.manifest.create({
                     add: {
                         place: 'funky-routes',
@@ -649,7 +763,8 @@ describe('HauteCouture', () => {
                         before: ['auth/default'],
                         after: ['auth/strategies']
                     }
-                });
+                })
+                    .map(ignoreFields);
 
                 const indexOf = (place, mf) => {
 


### PR DESCRIPTION
Resolves #41 and resolves #44

There are two features in here.

First, you can configure nested/recursive directories "on" by adding `recurse: true` to the manifest amendments (when calling `using()` or in your `.hc.js` file).  Aside from `recurse`, `include` and `exclude` are also functions `(filename, path) => Boolean` that can be used to specify which files are actually included (particularly when recursing).  By default anything under a `helpers` directory is excluded.

Second, scoped plugins are now supported.  For example, `plugins/@scope.package-name.js` will default to register the plugin `require('@scope/package-name')`.

In the next major version of haute-couture, I expect that `recurse` will default to `true` rather than `false`.