### PR TITLE
[feat] Disable use strict header via noUseStrictHeader: true

### DIFF
--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -15,6 +15,7 @@ exports.create = (amendments, includeExtras) => {
     }
 
     const recursive = !!amendments.recursive;
+    const noUseStrictHeader = !!amendments.noUseStrictHeader;
     const include = amendments.include;
     const exclude = (include || amendments.exclude) ?
         amendments.exclude :
@@ -46,7 +47,7 @@ exports.create = (amendments, includeExtras) => {
 
     return topoList.nodes.map((item) => {
 
-        item = Hoek.applyToDefaults({ recursive, include, exclude }, item);
+        item = Hoek.applyToDefaults({ recursive, noUseStrictHeader, include, exclude }, item);
 
         if (!includeExtras) {
             delete item.before;

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -14,15 +14,22 @@ exports.create = (amendments, includeExtras) => {
         amendments = { add: amendments };
     }
 
-    const recursive = !!amendments.recursive;
-    const noUseStrictHeader = !!amendments.noUseStrictHeader;
-    const include = amendments.include;
-    const exclude = (include || amendments.exclude) ?
-        amendments.exclude :
+    let {
+        recursive,
+        include,
+        exclude,
+        add,
+        remove,
+        ...meta
+    } = amendments;
+
+    recursive = !!recursive;
+    exclude = (include || exclude) ? exclude :
         (filename, path) => path.split(Path.sep).includes('helpers');
 
-    const add = Hoek.flatten([].concat(amendments.add || [])); // Allow nested [{}, [{}]]
-    const remove = [].concat(amendments.remove || []);
+    add = Hoek.flatten([].concat(add || [])); // Allow nested [{}, [{}]]
+    remove = [].concat(remove || []);
+
     const toObject = (collect, value) => ({ ...collect, [value]: true });
     const addLookup = add.map(({ place }) => place).reduce(toObject, {});
     const removeLookup = remove.reduce(toObject, {});
@@ -47,7 +54,7 @@ exports.create = (amendments, includeExtras) => {
 
     return topoList.nodes.map((item) => {
 
-        item = Hoek.applyToDefaults({ recursive, noUseStrictHeader, include, exclude }, item);
+        item = Hoek.applyToDefaults({ recursive, include, exclude, meta }, item);
 
         if (!includeExtras) {
             delete item.before;

--- a/test/index.js
+++ b/test/index.js
@@ -524,9 +524,9 @@ describe('HauteCouture', () => {
                     list: Joi.boolean(),
                     useFilename: Joi.func(),
                     recursive: Joi.boolean(),
-                    noUseStrictHeader: Joi.boolean(),
                     exclude: Joi.func(),
-                    include: Joi.func()
+                    include: Joi.func(),
+                    meta: Joi.object()
                 }));
 
                 const summarize = (item) => `${item.method}() at ${item.place}`;
@@ -568,12 +568,12 @@ describe('HauteCouture', () => {
                     list: Joi.boolean(),
                     useFilename: Joi.func(),
                     recursive: Joi.boolean(),
-                    noUseStrictHeader: Joi.boolean(),
                     exclude: Joi.func(),
                     include: Joi.func(),
                     before: Joi.array().items(Joi.string()).single(),
                     after: Joi.array().items(Joi.string()).single(),
-                    example: Joi.any()
+                    example: Joi.any(),
+                    meta: Joi.object()
                 }));
 
                 const summarize = (item) => `${item.method}() at ${item.place}`;
@@ -651,7 +651,7 @@ describe('HauteCouture', () => {
                     place: 'routes',
                     method: 'myRoute',
                     recursive: false,
-                    noUseStrictHeader: false
+                    meta: {}
                 });
             });
 
@@ -680,7 +680,7 @@ describe('HauteCouture', () => {
                     place: 'routes',
                     method: 'myRoute',
                     recursive: false,
-                    noUseStrictHeader: false
+                    meta: {}
                 });
 
                 const schwiftyItem = manifest.find((item) => item.place === 'models');
@@ -688,7 +688,7 @@ describe('HauteCouture', () => {
                     place: 'models',
                     method: 'mySchwifty',
                     recursive: false,
-                    noUseStrictHeader: false
+                    meta: {}
                 });
             });
 
@@ -704,8 +704,7 @@ describe('HauteCouture', () => {
                         },
                         {
                             place: 'funky-bind',
-                            method: 'funkyBind',
-                            noUseStrictHeader: true
+                            method: 'funkyBind'
                         }
                     ]
                 })
@@ -723,14 +722,14 @@ describe('HauteCouture', () => {
                     place: 'funky-routes',
                     method: 'funkyRoutes',
                     recursive: true,
-                    noUseStrictHeader: false
+                    meta: {}
                 });
 
                 expect(manifest[defaultLength + 1]).to.equal({
                     place: 'funky-bind',
                     method: 'funkyBind',
                     recursive: false,
-                    noUseStrictHeader: true
+                    meta: {}
                 });
             });
 
@@ -757,7 +756,7 @@ describe('HauteCouture', () => {
                     place: 'funky-routes',
                     method: 'funkyRoutes',
                     recursive: false,
-                    noUseStrictHeader: false
+                    meta: {}
                 });
             });
 
@@ -803,6 +802,23 @@ describe('HauteCouture', () => {
 
                 expect(funkyIndex).to.be.above(indexOf('auth/strategies', manifest));
                 expect(funkyIndex).to.be.below(indexOf('auth/default', manifest));
+            });
+
+            it('passes through additional keys as meta on each item.', () => {
+
+                const defaultManifest = HauteCouture.manifest.create().map(ignoreFields);
+                const manifest = HauteCouture.manifest.create({
+                    exampleUseStrict: false
+                })
+                    .map(ignoreFields);
+
+                expect(manifest.length).to.equal(defaultManifest.length);
+
+                defaultManifest.forEach((item, i) => {
+
+                    expect(item).to.not.equal(manifest[i]);
+                    expect({ ...item, meta: { exampleUseStrict: false } }).to.equal(manifest[i]);
+                });
             });
         });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -524,6 +524,7 @@ describe('HauteCouture', () => {
                     list: Joi.boolean(),
                     useFilename: Joi.func(),
                     recursive: Joi.boolean(),
+                    noUseStrictHeader: Joi.boolean(),
                     exclude: Joi.func(),
                     include: Joi.func()
                 }));
@@ -567,6 +568,7 @@ describe('HauteCouture', () => {
                     list: Joi.boolean(),
                     useFilename: Joi.func(),
                     recursive: Joi.boolean(),
+                    noUseStrictHeader: Joi.boolean(),
                     exclude: Joi.func(),
                     include: Joi.func(),
                     before: Joi.array().items(Joi.string()).single(),
@@ -630,7 +632,7 @@ describe('HauteCouture', () => {
                 });
             });
 
-            it('replaces items in the manifest by place.', () => {
+            it('replaces item in the manifest by place.', () => {
 
                 const defaultManifest = HauteCouture.manifest.create().map(ignoreFields);
                 const manifest = HauteCouture.manifest.create({
@@ -648,7 +650,8 @@ describe('HauteCouture', () => {
                 expect(routeItem).to.equal({
                     place: 'routes',
                     method: 'myRoute',
-                    recursive: false
+                    recursive: false,
+                    noUseStrictHeader: false
                 });
             });
 
@@ -676,14 +679,16 @@ describe('HauteCouture', () => {
                 expect(routeItem).to.equal({
                     place: 'routes',
                     method: 'myRoute',
-                    recursive: false
+                    recursive: false,
+                    noUseStrictHeader: false
                 });
 
                 const schwiftyItem = manifest.find((item) => item.place === 'models');
                 expect(schwiftyItem).to.equal({
                     place: 'models',
                     method: 'mySchwifty',
-                    recursive: false
+                    recursive: false,
+                    noUseStrictHeader: false
                 });
             });
 
@@ -699,7 +704,8 @@ describe('HauteCouture', () => {
                         },
                         {
                             place: 'funky-bind',
-                            method: 'funkyBind'
+                            method: 'funkyBind',
+                            noUseStrictHeader: true
                         }
                     ]
                 })
@@ -716,13 +722,15 @@ describe('HauteCouture', () => {
                 expect(manifest[defaultLength]).to.equal({
                     place: 'funky-routes',
                     method: 'funkyRoutes',
-                    recursive: true
+                    recursive: true,
+                    noUseStrictHeader: false
                 });
 
                 expect(manifest[defaultLength + 1]).to.equal({
                     place: 'funky-bind',
                     method: 'funkyBind',
-                    recursive: false
+                    recursive: false,
+                    noUseStrictHeader: true
                 });
             });
 
@@ -748,7 +756,8 @@ describe('HauteCouture', () => {
                 expect(manifest[defaultLength]).to.equal({
                     place: 'funky-routes',
                     method: 'funkyRoutes',
-                    recursive: false
+                    recursive: false,
+                    noUseStrictHeader: false
                 });
             });
 


### PR DESCRIPTION
Allow setting `noUseStrictHeader: true` on the global scope, similar to how `recursive` works.