### PR TITLE
fix: schwifty models should require @hapi/joi

### DIFF
--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -337,7 +337,7 @@ internals.manifest = [
         method: 'schwifty',
         list: true,
         after: ['plugins', 'path'],
-        example: { $requires: ['schwifty', 'joi'], $value: internals.SchwiftyExample }
+        example: { $requires: ['schwifty', '@hapi/joi'], $value: internals.SchwiftyExample }
     },
     {   // Schmervice services
         place: 'services',


### PR DESCRIPTION
Currently the Schwifty model example requires `joi` and not `@hapi/joi`, so there's a require error instantly.