### PR TITLE
fix: single-export multi-method routes fail

### DIFF
--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -370,7 +370,7 @@ internals.manifest = [
         list: true,
         useFilename: (filename, value, path) => {
 
-            if (Array.isArray(value)) {
+            if (Array.isArray(value) || Array.isArray(value.method)) {
                 return value;
             }
 

--- a/test/closet/routes/multi-method-route.js
+++ b/test/closet/routes/multi-method-route.js
@@ -1,6 +1,8 @@
 'use strict';
 
 module.exports = {
+    // This case is significant because we should not auto-assign an
+    // id to routes with multiple methods, as it is not allowed by hapi.
     method: ['get', 'post'],
     path: '/multi-method-route',
     handler: () => 'multi-method-route'

--- a/test/closet/routes/multi-method-route.js
+++ b/test/closet/routes/multi-method-route.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+    method: ['get', 'post'],
+    path: '/multi-method-route',
+    handler: () => 'multi-method-route'
+};

--- a/test/index.js
+++ b/test/index.js
@@ -407,6 +407,8 @@ describe('HauteCouture', () => {
         expect(bigServer.lookup('arr-routes')).to.not.exist();
         expect(bigServer.match('get', '/arr-route-one')).to.exist();
         expect(bigServer.match('get', '/arr-route-two')).to.exist();
+        expect(bigServer.match('get', '/multi-method-route')).to.exist();
+        expect(bigServer.match('post', '/multi-method-route')).to.exist();
     });
 
     it('defines subscriptions in subscriptions/.', async (flags) => {

--- a/test/index.js
+++ b/test/index.js
@@ -405,6 +405,7 @@ describe('HauteCouture', () => {
         expect(bigServer.lookup('id-config-route')).to.exist();
         expect(bigServer.lookup('test-route')).to.exist();
         expect(bigServer.lookup('arr-routes')).to.not.exist();
+        expect(bigServer.lookup('multi-method-route')).to.not.exist();
         expect(bigServer.match('get', '/arr-route-one')).to.exist();
         expect(bigServer.match('get', '/arr-route-two')).to.exist();
         expect(bigServer.match('get', '/multi-method-route')).to.exist();


### PR DESCRIPTION
Currently routes that are the sole export of a file (i.e non-array) but have multiple methods defined are getting an `id` assigned to them which https://hapi.dev/api/?v=20.1.0#-routeoptionsid says isn't allowed, and results in the below error. Handling them the same as array exports resolves the issue.

```
web_1         | Error: server.route() called by haute using /app/lib/routes/graphql.ts: Route id graphql for path /graphql conflicts with existing path /graphql
web_1         |     at new module.exports (/app/node_modules/@hapi/hoek/lib/error.js:23:19)
web_1         |     at Object.module.exports [as assert] (/app/node_modules/@hapi/hoek/lib/assert.js:20:11)
web_1         |     at exports.Router.internals.Router.internals.Router.add (/app/node_modules/@hapi/call/lib/index.js:75:14)
web_1         |     at internals.Server._addRoute (/app/node_modules/@hapi/hapi/lib/server.js:533:46)
web_1         |     at internals.Server.route (/app/node_modules/@hapi/hapi/lib/server.js:518:26)
web_1         |     at Object.internals.callMethod (/app/node_modules/haute-couture/node_modules/haute/lib/index.js:210:26)
web_1         |     at makeCall (/app/node_modules/haute-couture/node_modules/haute/lib/index.js:180:25)
web_1         |     at Object.exports.run (/app/node_modules/haute-couture/node_modules/haute/lib/index.js:184:15)
web_1         |     at /app/node_modules/haute-couture/lib/index.js:33:16
web_1         |     at Object.register (/app/lib/index.ts:26:9)
```