### PR TITLE
Support .hc.ts file extension

### DIFF
--- a/API.md
+++ b/API.md
@@ -49,6 +49,8 @@ See the amendment example below for illustration, noting that the format of `.hc
 
 When a call to `HauteCouture.compose(server, options, composeOptions)` specifies no `composeOptions.amendments`, haute-couture will check the relevant directory `composeOptions.dirname` for a file named `.hc.js`.  Any amendments exported by this file are used identically to amendments passed as an argument.  This is a nice way to keep haute-couture-related configuration separate from your plugin code, and also offer a standard way for tools such as the [pal CLI](https://github.com/devinivy/paldo) to cater to your particular usage of haute-couture.
 
+Haute-couture supports other file extensions as well, such as .hs.json and .hc.ts.
+
 #### Amendment example
 
 This example demonstrates how to use a `.hc.js` file in order to swap-out [schwifty's](https://github.com/hapipal/schwifty) handling of [Objection ORM](http://vincit.github.io/objection.js/) models for a much simplified handling of [Mongoose](https://mongoosejs.com) models.  You can even continue to use [`hpal make`](https://github.com/hapipal/hpal#hpal-make) to scaffold your Mongoose models inside the `models/` directory.

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,8 @@ const Manifest = require('./manifest');
 
 const internals = {};
 
+exports.getDefaultExport = Haute.getDefaultExport;
+
 exports.default = Manifest.default;
 
 exports.amendment = Manifest.amendment;
@@ -34,10 +36,11 @@ exports.composeWith = (composeOptions) => {
 
 internals.maybeGetHcFile = (dirname) => {
 
-    const path = Path.join(dirname, '.hc.js');
+    const path = Path.join(dirname, '.hc');
 
     try {
-        return require(path);
+        const resolved = require.resolve(path);
+        return exports.getDefaultExport(require(resolved), resolved);
     }
     catch (err) {
         // Must be an error specifically from trying to require the passed (normalized) path

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@hapi/hoek": "9.x.x",
     "@hapi/topo": "5.x.x",
-    "haute": ">=3.1.x <4",
+    "haute": "3.2.x <4",
     "parent-module": "2.x.x"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@hapi/hoek": "9.x.x",
     "@hapi/topo": "5.x.x",
-    "haute": "3.2.x <4",
+    "haute": ">=3.2.x <4",
     "parent-module": "2.x.x"
   },
   "peerDependencies": {

--- a/test/closet/hc-file-ts/.hc.ts
+++ b/test/closet/hc-file-ts/.hc.ts
@@ -1,0 +1,10 @@
+'use strict';
+
+// This is the effective format of a ts file with `export default {/* ... */}`
+exports.default = {
+    methods: false,
+    controllers: {
+        method: 'method',
+        list: true
+    }
+};

--- a/test/closet/hc-file-ts/controllers.ts
+++ b/test/closet/hc-file-ts/controllers.ts
@@ -1,0 +1,14 @@
+'use strict';
+
+exports.default = [
+    {
+        name: 'controllerOne',
+        method: () => 'controller-one',
+        options: {}
+    },
+    {
+        name: 'controllerTwo',
+        method: () => 'controller-two',
+        options: {}
+    }
+];

--- a/test/closet/hc-file-ts/methods.ts
+++ b/test/closet/hc-file-ts/methods.ts
@@ -1,0 +1,14 @@
+'use strict';
+
+exports.default = [
+    {
+        name: 'methodOne',
+        method: () => 'method-one',
+        options: {}
+    },
+    {
+        name: 'methodTwo',
+        method: () => 'method-two',
+        options: {}
+    }
+];

--- a/test/index.js
+++ b/test/index.js
@@ -1142,7 +1142,7 @@ describe('HauteCouture', () => {
         });
     });
 
-    describe('.hc.js', () => {
+    describe('.hc file', () => {
 
         it('specifies amendments for the current directory used by haute-couture.', async () => {
 
@@ -1152,6 +1152,29 @@ describe('HauteCouture', () => {
                 name: 'my-hc-plugin',
                 register: HauteCouture.composeWith({
                     dirname: `${__dirname}/closet/hc-file`
+                })
+            };
+
+            await server.register(plugin);
+
+            expect(server.methods.controllerOne()).to.equal('controller-one');
+            expect(server.methods.controllerTwo()).to.equal('controller-two');
+            expect(server.methods.methodOne).to.not.exist();
+            expect(server.methods.methodTwo).to.not.exist();
+        });
+
+        it('supports .hc.ts files.', async (flags) => {
+
+            // Emulate ts-node
+            require.extensions['.ts'] = require.extensions['.js'];
+            flags.onCleanup = () => delete require.extensions['.ts'];
+
+            const server = Hapi.server();
+
+            const plugin = {
+                name: 'my-hc-plugin',
+                register: HauteCouture.composeWith({
+                    dirname: `${__dirname}/closet/hc-file-ts`
                 })
             };
 


### PR DESCRIPTION
In followup to https://github.com/devinivy/haute/pull/18, here we add support for additional .hc file extensions, notably .hc.ts for typescript users 🙂 