### PR TITLE
Fix composeWith() using default dirname

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,10 +18,10 @@ exports.manifest = Manifest.manifest;
 
 exports.compose = async (server, options, { dirname, amendments } = {}) => {
 
-    // Protect from usage such as { name, register: HauteCouture.compose }
     dirname = dirname || Path.dirname(ParentModule());
     amendments = amendments || internals.maybeGetHcFile(dirname);
 
+    // Protect from usage such as { name, register: HauteCouture.compose }
     Hoek.assert(Path.relative(Path.resolve(dirname, '..', '..', '..'), dirname) !== Path.join('@hapi', 'hapi', 'lib'), 'You may not have called HauteCouture.compose(), which is necessary to determine the correct dirname. Consider using HauteCouture.composeWith() for your purposes.');
 
     const manifest = Manifest.manifest(amendments, dirname);

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,8 +18,11 @@ exports.manifest = Manifest.manifest;
 
 exports.compose = async (server, options, { dirname, amendments } = {}) => {
 
+    // Protect from usage such as { name, register: HauteCouture.compose }
     dirname = dirname || Path.dirname(ParentModule());
     amendments = amendments || internals.maybeGetHcFile(dirname);
+
+    Hoek.assert(Path.relative(Path.resolve(dirname, '..', '..', '..'), dirname) !== Path.join('@hapi', 'hapi', 'lib'), 'You may not have called HauteCouture.compose(), which is necessary to determine the correct dirname. Consider using HauteCouture.composeWith() for your purposes.');
 
     const manifest = Manifest.manifest(amendments, dirname);
     const calls = Haute.calls('server', manifest);

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,9 +27,11 @@ exports.compose = async (server, options, { dirname, amendments } = {}) => {
     return await Haute.run(calls, server, options);
 };
 
-exports.composeWith = (composeOptions) => {
+exports.composeWith = ({ dirname, amendments } = {}) => {
 
-    return (server, options) => exports.compose(server, options, composeOptions);
+    dirname = dirname || Path.dirname(ParentModule());
+
+    return (server, options) => exports.compose(server, options, { dirname, amendments });
 };
 
 internals.maybeGetHcFile = (dirname) => {

--- a/test/closet/compose-with-default/.hc.js
+++ b/test/closet/compose-with-default/.hc.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+    methods: false,
+    controllers: {
+        method: 'method',
+        list: true
+    }
+};

--- a/test/closet/compose-with-default/controllers.js
+++ b/test/closet/compose-with-default/controllers.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = [
+    {
+        name: 'controllerOne',
+        method: () => 'controller-one',
+        options: {}
+    },
+    {
+        name: 'controllerTwo',
+        method: () => 'controller-two',
+        options: {}
+    }
+];

--- a/test/closet/compose-with-default/index.js
+++ b/test/closet/compose-with-default/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const HauteCouture = require('../../..');
+
+module.exports = {
+    name: 'compose-with-default',
+    register: HauteCouture.composeWith()
+};

--- a/test/closet/compose-with-default/methods.js
+++ b/test/closet/compose-with-default/methods.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = [
+    {
+        name: 'methodOne',
+        method: () => 'method-one',
+        options: {}
+    },
+    {
+        name: 'methodTwo',
+        method: () => 'method-two',
+        options: {}
+    }
+];

--- a/test/index.js
+++ b/test/index.js
@@ -139,6 +139,18 @@ describe('HauteCouture', () => {
         expect(server.methods.methodTwo).to.not.exist();
     });
 
+    it('throws when failing to call compose().', async () => {
+
+        const server = Hapi.server();
+
+        const plugin = {
+            name: 'my-failing-plugin',
+            register: HauteCouture.compose
+        };
+
+        await expect(server.register(plugin)).to.reject('You may not have called HauteCouture.compose(), which is necessary to determine the correct dirname. Consider using HauteCouture.composeWith() for your purposes.');
+    });
+
     it('can look in specific directory.', async () => {
 
         const server = Hapi.server();

--- a/test/index.js
+++ b/test/index.js
@@ -127,6 +127,18 @@ describe('HauteCouture', () => {
         expect(bigServer.registrations['@hapi/vision']).to.exist();
     });
 
+    it('looks in the caller\'s directory when using composeWith().', async () => {
+
+        const server = Hapi.server();
+
+        await server.register(require('./closet/compose-with-default'));
+
+        expect(server.methods.controllerOne()).to.equal('controller-one');
+        expect(server.methods.controllerTwo()).to.equal('controller-two');
+        expect(server.methods.methodOne).to.not.exist();
+        expect(server.methods.methodTwo).to.not.exist();
+    });
+
     it('can look in specific directory.', async () => {
 
         const server = Hapi.server();


### PR DESCRIPTION
When using `composeWith()`, the default `dirname` is incorrectly resolved, typically within hapi rather than the user's project.  This PR addresses that by calculating the default `dirname` using `parent-module` based from the correct function call.