### PR TITLE
Fix inferring hc file location within ESM project

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Path = require('path');
+const Url = require('url');
 const Hoek = require('@hapi/hoek');
 const ParentModule = require('parent-module');
 const Mo = require('mo-walk');
@@ -21,7 +22,7 @@ exports.manifest = Manifest.manifest;
 
 exports.compose = async (server, options, { dirname, amendments } = {}) => {
 
-    dirname = dirname || Path.dirname(ParentModule());
+    dirname = dirname || Path.dirname(internals.normalizeToPath(ParentModule()));
     amendments = amendments || await internals.maybeGetHcFile(dirname);
 
     // Protect from usage such as { name, register: HauteCouture.compose }
@@ -35,7 +36,7 @@ exports.compose = async (server, options, { dirname, amendments } = {}) => {
 
 exports.composeWith = ({ dirname, amendments } = {}) => {
 
-    dirname = dirname || Path.dirname(ParentModule());
+    dirname = dirname || Path.dirname(internals.normalizeToPath(ParentModule()));
 
     return (server, options) => exports.compose(server, options, { dirname, amendments });
 };
@@ -47,4 +48,9 @@ internals.maybeGetHcFile = async (dirname) => {
     if (resolved) {
         return exports.getDefaultExport(...resolved);
     }
+};
+
+internals.normalizeToPath = (path) => {
+
+    return path.startsWith('file:/') ? Url.fileURLToPath(path) : path;
 };

--- a/test/closet/hc-file-esm-default/.hc.mjs
+++ b/test/closet/hc-file-esm-default/.hc.mjs
@@ -1,0 +1,7 @@
+export default {
+    methods: false,
+    controllers: {
+        method: 'method',
+        list: true
+    }
+};

--- a/test/closet/hc-file-esm-default/controllers.mjs
+++ b/test/closet/hc-file-esm-default/controllers.mjs
@@ -1,0 +1,14 @@
+'use strict';
+
+export default [
+    {
+        name: 'controllerOne',
+        method: () => 'controller-one',
+        options: {}
+    },
+    {
+        name: 'controllerTwo',
+        method: () => 'controller-two',
+        options: {}
+    }
+];

--- a/test/closet/hc-file-esm-default/controllers.mjs
+++ b/test/closet/hc-file-esm-default/controllers.mjs
@@ -1,5 +1,3 @@
-'use strict';
-
 export default [
     {
         name: 'controllerOne',

--- a/test/closet/hc-file-esm-default/index.mjs
+++ b/test/closet/hc-file-esm-default/index.mjs
@@ -1,0 +1,9 @@
+import HauteCouture from '../../../lib/index.js'
+
+export const plugin = {
+    name: 'hc-file-esm-default',
+    async register(server, options) {
+
+        await HauteCouture.compose(server, options);
+    }
+};

--- a/test/closet/hc-file-esm-default/methods.mjs
+++ b/test/closet/hc-file-esm-default/methods.mjs
@@ -1,0 +1,12 @@
+export default [
+    {
+        name: 'methodOne',
+        method: () => 'method-one',
+        options: {}
+    },
+    {
+        name: 'methodTwo',
+        method: () => 'method-two',
+        options: {}
+    }
+];

--- a/test/index.js
+++ b/test/index.js
@@ -101,7 +101,7 @@ describe('HauteCouture', () => {
         });
     };
 
-    const bigServer = Hapi.server();
+    const bigServer = Hapi.server({ host: 'localhost' });
 
     before({ timeout: 4000 }, async () => {
 
@@ -132,6 +132,19 @@ describe('HauteCouture', () => {
         const server = Hapi.server();
 
         await server.register(require('./closet/compose-with-default'));
+
+        expect(server.methods.controllerOne()).to.equal('controller-one');
+        expect(server.methods.controllerTwo()).to.equal('controller-two');
+        expect(server.methods.methodOne).to.not.exist();
+        expect(server.methods.methodTwo).to.not.exist();
+    });
+
+    it('looks in the caller\'s directory when using ESM.', async () => {
+
+        const server = Hapi.server();
+
+        const plugin = await import('./closet/hc-file-esm-default/index.mjs');
+        await server.register(plugin);
 
         expect(server.methods.controllerOne()).to.equal('controller-one');
         expect(server.methods.controllerTwo()).to.equal('controller-two');


### PR DESCRIPTION
There was an issue with inferring the location of the hc file when `dirname` was not explicitly passed in an ESM project.  This resolves that issue. Thanks to @afgallo for the clear reproduction https://github.com/afgallo/hpal-esmodule